### PR TITLE
include config.h to allow using getline on freebsd

### DIFF
--- a/src/ZYSymbolLookup.cc
+++ b/src/ZYSymbolLookup.cc
@@ -20,6 +20,10 @@
  */
 
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "ZYSymbolLookup.h"
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This is the same as https://github.com/libpinyin/libpinyin/pull/92. To use `getline` on FreeBSD, we have to define a macro such as `_GNU_SOURCE` to enable the declaration in the header file.