### PR TITLE
Set layout to us

### DIFF
--- a/src/libzhuyin.xml.in.in
+++ b/src/libzhuyin.xml.in.in
@@ -21,7 +21,7 @@
                         ...
                         </author>
 			<icon>${pkgdatadir}/icons/ibus-zhuyin.svg</icon>
-			<layout>default</layout>
+			<layout>us</layout>
 			<longname>New Zhuyin</longname>
 			<description>New Zhuyin input method</description>
 			<rank>99</rank>


### PR DESCRIPTION
For people with keyboard unlike the US one(ex. Norwegian, Swedish, Danish..), the keysyms appear on the wrong letters.
Setting the US keyboard Layout as default, fixes this.
An alternative is to find the Taiwanese one with English Characters, but I could not find it.