### PR TITLE
changing keyboard layout to us

### DIFF
--- a/src/libzhuyin.xml.in.in
+++ b/src/libzhuyin.xml.in.in
@@ -21,7 +21,7 @@
                         ...
                         </author>
 			<icon>${pkgdatadir}/icons/ibus-zhuyin.svg</icon>
-			<layout>default</layout>
+			<layout>us</layout>
 			<longname>New Zhuyin</longname>
 			<description>New Zhuyin input method</description>
 			<rank>99</rank>


### PR DESCRIPTION
(Layout can also be set to 'tw', maybe 'ch' and 'zh' but I haven't tried those, the 'us' layout is more common hence the choice)
Keyboards that have a different layout from the us will have the zhuyin keysums appearing on the wrong letter.
Examples:
On a us/tw/ch latin layout: / -> ㄥ
On a nordic/german layout: shift+7 -> ㄥ
On a french layout: shift+: -> ㄥ

Setting the layout to 'us' will make sure that the zhuyin keysums appear on the correct key, similar to a zhuyin keyboard.
The zhuyin keysums are mapped to latin keysums hence the keysums must be placed correctly.

It does not matter which physical keyboard (german, french, italian, nordic, spanish, vietnamese, chinese, taiwanese...), as the layout is just a mapping from keycodes to keysyms (e.g: keycode 30 = a on most keyboards, but on a french keyboard keycode 30 = q). Setting it to 'us' will just make sure that all keycodes have the correct keysums on the corresponding physical keys.
This will work on all standard keyboards.
On nonstandard keyboards, this is not really relevant as the user of such a keyboard would have to write the key layout themselves. Using default on a non-standard would not help as in many cases the keysums would be missing or just be weirdly placed anyway.

As a reference, ibus-chewing also sets their layout to 'us' this https://raw.githubusercontent.com/definite/ibus-chewing/master/data/chewing.xml.in

Wikipedia reference for why the us keyboard layout is sufficient https://en.wikipedia.org/wiki/Keyboard_layout#Taiwan